### PR TITLE
Added CLR mappings for "uuid" and "guid" SQL types

### DIFF
--- a/src/Simple.Data.Sqlite/SqliteTypeResolver.cs
+++ b/src/Simple.Data.Sqlite/SqliteTypeResolver.cs
@@ -10,6 +10,8 @@ namespace Simple.Data.Sqlite
                 {"image", typeof (byte[])},
                 {"text", typeof (string)},
                 {"uniqueidentifier", typeof (Guid)},
+                {"guid", typeof (Guid)},
+                {"uuid", typeof (Guid)},
                 {"date", typeof (DateTime)},
                 {"time", typeof (DateTime)},
                 {"datetime2", typeof (DateTime)},


### PR DESCRIPTION
This changes enables GUID/UUID strings stored in columns typed as "guid" or "uuid" to be correctly converted back to System.Guid objects when retrieving data.
